### PR TITLE
Addresses napalm-automation/napalm-iosxr#11

### DIFF
--- a/napalm_iosxr/iosxr.py
+++ b/napalm_iosxr/iosxr.py
@@ -1564,8 +1564,9 @@ class IOSXRDriver(NetworkDriver):
                 if not last_probe_host_name:
                     last_probe_host_name = last_probe_ip_address
                 last_hop_dict['probes'][last_probe_index] = {
-                    'ip_address': last_probe_ip_address,
-                    'host_name': last_probe_host_name
+                    'ip_address': unicode(last_probe_ip_address),
+                    'host_name': unicode(last_probe_host_name),
+                    'rtt': -1.0
                 }
                 continue
             if tag_name == 'HopAddress':


### PR DESCRIPTION
Problem is that some hops don't don't contain the `DeltaTime` tag. I guess they are the ones that didn't return a TTL expired error. However, I don't have a real device to do some tests and I am not sure if this patch actually solves the problem because the XML output of a traceroute on IOS-XR is the biggest piece of shit I have seen in a looooong time. It's sad you have reverse engineer a device function because the XML it returns is pure garbage.
