### PR TITLE
Fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-napalm_base
+napalm-base
 pyIOSXR
 netaddr


### PR DESCRIPTION
Not sure this will fix https://github.com/napalm-automation/napalm-iosxr/issues/19, but this definitely has to be `napalm-base`.
