### PR TITLE
Changes for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
 - 2.7
+- 3.4
+- 3.5
 install:
 - pip install -r requirements-dev.txt
 - pip install .

--- a/napalm_iosxr/iosxr.py
+++ b/napalm_iosxr/iosxr.py
@@ -39,6 +39,7 @@ from napalm_base.exceptions import ConnectionException
 from napalm_base.exceptions import MergeConfigException
 from napalm_base.exceptions import ReplaceConfigException
 from napalm_base.exceptions import CommandTimeoutException
+from napalm_base.utils.py23_compat import text_type
 
 
 class IOSXRDriver(NetworkDriver):
@@ -152,16 +153,16 @@ class IOSXRDriver(NetworkDriver):
         platform_attr_tree = facts_rpc_reply.xpath(platform_attr_xpath)[0]
 
         hostname = napalm_base.helpers.convert(
-            unicode, napalm_base.helpers.find_txt(system_time_tree, 'Hostname'))
+            text_type, napalm_base.helpers.find_txt(system_time_tree, 'Hostname'))
         uptime = napalm_base.helpers.convert(
             int, napalm_base.helpers.find_txt(system_time_tree, 'Uptime'), -1)
         serial = napalm_base.helpers.convert(
-            unicode, napalm_base.helpers.find_txt(platform_attr_tree, 'SerialNumber'))
+            text_type, napalm_base.helpers.find_txt(platform_attr_tree, 'SerialNumber'))
         os_version = napalm_base.helpers.convert(
-            unicode, napalm_base.helpers.find_txt(platform_attr_tree, 'SoftwareRevision'))
+            text_type, napalm_base.helpers.find_txt(platform_attr_tree, 'SoftwareRevision'))
         model = napalm_base.helpers.convert(
-            unicode, napalm_base.helpers.find_txt(platform_attr_tree, 'ModelName'))
-        interface_list = self.get_interfaces().keys()
+            text_type, napalm_base.helpers.find_txt(platform_attr_tree, 'ModelName'))
+        interface_list = sorted(list(self.get_interfaces().keys()))
 
         facts.update({
             'os_version': os_version,
@@ -190,7 +191,8 @@ class IOSXRDriver(NetworkDriver):
 
         interfaces_rpc_request = '<Get><Operational><Interfaces/></Operational></Get>'
 
-        interfaces_rpc_reply = ETREE.fromstring(self.device.make_rpc_call(interfaces_rpc_request))
+        interfaces_rpc_reply = ETREE.fromstring(
+            self.device.make_rpc_call(interfaces_rpc_request))
 
         for interface_tree in interfaces_rpc_reply.xpath('.//Interfaces/InterfaceTable/Interface'):
             interface_name = napalm_base.helpers.find_txt(interface_tree, 'Naming/InterfaceName')
@@ -318,12 +320,12 @@ class IOSXRDriver(NetworkDriver):
 
             if vrf == "global":
                 this_vrf['router_id'] = napalm_base.helpers.convert(
-                    unicode, napalm_base.helpers.find_txt(result_tree,
+                    text_type, napalm_base.helpers.find_txt(result_tree,
                         'Get/Operational/BGP/InstanceTable/Instance/InstanceActive/DefaultVRF\
                         /GlobalProcessInfo/VRF/RouterID'))
             else:
                 this_vrf['router_id'] = napalm_base.helpers.convert(
-                    unicode, napalm_base.helpers.find_txt(result_tree,
+                    text_type, napalm_base.helpers.find_txt(result_tree,
                         'Get/Operational/BGP/InstanceTable/Instance/InstanceActive/VRFTable/VRF\
                         /GlobalProcessInfo/VRF/RouterID'))
 
@@ -336,13 +338,13 @@ class IOSXRDriver(NetworkDriver):
                 this_neighbor['remote_as'] = napalm_base.helpers.convert(
                     int, napalm_base.helpers.find_txt(neighbor, 'RemoteAS'))
                 this_neighbor['remote_id'] = napalm_base.helpers.convert(
-                    unicode, napalm_base.helpers.find_txt(neighbor, 'RouterID'))
+                    text_type, napalm_base.helpers.find_txt(neighbor, 'RouterID'))
 
                 if napalm_base.helpers.find_txt(neighbor, 'ConnectionAdminStatus') is "1":
                     this_neighbor['is_enabled'] = True
                 try:
                     this_neighbor['description'] = napalm_base.helpers.convert(
-                        unicode, napalm_base.helpers.find_txt(neighbor, 'Description'))
+                        text_type, napalm_base.helpers.find_txt(neighbor, 'Description'))
                 except AttributeError:
                     this_neighbor['description'] = u''
 
@@ -560,7 +562,7 @@ class IOSXRDriver(NetworkDriver):
         #
 
         slot_list = set()
-        for category, slot in active_modules.iteritems():
+        for category, slot in active_modules.items():
             slot_list |= set(slot)
 
         if not is_xrv:
@@ -599,9 +601,9 @@ class IOSXRDriver(NetworkDriver):
 
             lldp[local_interface].append({
                 'hostname': napalm_base.helpers.convert(
-                    unicode, n.split()[0]),
+                    text_type, n.split()[0]),
                 'port': napalm_base.helpers.convert(
-                    unicode, n.split()[4])
+                    text_type, n.split()[4])
             })
 
         return lldp
@@ -616,24 +618,24 @@ class IOSXRDriver(NetworkDriver):
 
         for neighbor in result_tree.xpath('.//Neighbors/DetailTable/Detail/Entry'):
             interface_name = napalm_base.helpers.convert(
-                unicode, napalm_base.helpers.find_txt(neighbor, 'ReceivingInterfaceName'))
+                text_type, napalm_base.helpers.find_txt(neighbor, 'ReceivingInterfaceName'))
             parent_interface = napalm_base.helpers.convert(
-                unicode, napalm_base.helpers.find_txt(neighbor, 'ReceivingParentInterfaceName'))
+                text_type, napalm_base.helpers.find_txt(neighbor, 'ReceivingParentInterfaceName'))
             chassis_id_raw = napalm_base.helpers.find_txt(neighbor, 'ChassisID')
             chassis_id = napalm_base.helpers.convert(
                 napalm_base.helpers.mac, chassis_id_raw, chassis_id_raw)
             port_id = napalm_base.helpers.convert(
-                unicode, napalm_base.helpers.find_txt(neighbor, 'PortIDDetail'))
+                text_type, napalm_base.helpers.find_txt(neighbor, 'PortIDDetail'))
             port_descr = napalm_base.helpers.convert(
-                unicode, napalm_base.helpers.find_txt(neighbor, 'Detail/PortDescription'))
+                text_type, napalm_base.helpers.find_txt(neighbor, 'Detail/PortDescription'))
             system_name = napalm_base.helpers.convert(
-                unicode, napalm_base.helpers.find_txt(neighbor, 'Detail/SystemName'))
+                text_type, napalm_base.helpers.find_txt(neighbor, 'Detail/SystemName'))
             system_descr = napalm_base.helpers.convert(
-                unicode, napalm_base.helpers.find_txt(neighbor, 'Detail/SystemDescription'))
+                text_type, napalm_base.helpers.find_txt(neighbor, 'Detail/SystemDescription'))
             system_capabilities = napalm_base.helpers.convert(
-                unicode, napalm_base.helpers.find_txt(neighbor, 'Detail/SystemCapabilities'))
+                text_type, napalm_base.helpers.find_txt(neighbor, 'Detail/SystemCapabilities'))
             enabled_capabilities = napalm_base.helpers.convert(
-                unicode, napalm_base.helpers.find_txt(neighbor, 'Detail/EnabledCapabilities'))
+                text_type, napalm_base.helpers.find_txt(neighbor, 'Detail/EnabledCapabilities'))
 
             if interface_name not in lldp_neighbors.keys():
                 lldp_neighbors[interface_name] = []
@@ -659,9 +661,9 @@ class IOSXRDriver(NetworkDriver):
 
         for command in commands:
             try:
-                cli_output[unicode(command)] = unicode(self.device._execute_show(command))
+                cli_output[text_type(command)] = text_type(self.device._execute_show(command))
             except TimeoutError:
-                cli_output[unicode(command)] = 'Execution of command \
+                cli_output[text_type(command)] = 'Execution of command \
                     "{command}" took too long! Please adjust your params!'.format(command=command)
                 raise CommandTimeoutException(str(cli_output))
 
@@ -806,7 +808,7 @@ class IOSXRDriver(NetworkDriver):
                 'apply_groups': [],  # on IOS-XR will always be empty list!
                 'description': description,
                 'local_as': local_as,
-                'type': unicode(bgp_type),
+                'type': text_type(bgp_type),
                 'import_policy': import_policy,
                 'export_policy': export_policy,
                 'local_address': local_address,
@@ -833,13 +835,14 @@ class IOSXRDriver(NetworkDriver):
         <Naming><InstanceName>default</InstanceName></Naming><ConfigInstanceVRFTable/>\
         </ConfigInstance></ConfigInstanceTable></BGP></Operational></Get>'
 
-        active_vrfs_rpc_reply = ETREE.fromstring(self.device.make_rpc_call(active_vrfs_rpc_request))
+        active_vrfs_rpc_reply = ETREE.fromstring(
+            self.device.make_rpc_call(active_vrfs_rpc_request))
         active_vrfs_tree = active_vrfs_rpc_reply.xpath('.//ConfigVRF')
 
         for active_vrf_tree in active_vrfs_tree:
             active_vrfs.append(napalm_base.helpers.find_txt(active_vrf_tree, 'Naming/VRFName'))
 
-        unique_active_vrfs = set(active_vrfs)
+        unique_active_vrfs = sorted(set(active_vrfs))
 
         bgp_neighbors_vrf_all_rpc = '<Get><Operational><BGP><InstanceTable><Instance><Naming>\
         <InstanceName>default</InstanceName></Naming>'
@@ -926,7 +929,7 @@ class IOSXRDriver(NetworkDriver):
                 if connection_state == u'Estab':
                     connection_state = u'Established'
                 previous_connection_state = napalm_base.helpers.convert(
-                    unicode, _BGP_STATE_.get(napalm_base.helpers.find_txt(
+                    text_type, _BGP_STATE_.get(napalm_base.helpers.find_txt(
                         neighbor, 'PreviousConnectionState', '0')))
                 active_prefix_count = napalm_base.helpers.convert(
                     int, napalm_base.helpers.find_txt(
@@ -953,7 +956,7 @@ class IOSXRDriver(NetworkDriver):
                     or vrf_keepalive
                 configured_keepalive = napalm_base.helpers.convert(
                     int, napalm_base.helpers.find_txt(neighbor, 'ConfiguredKeepalive'), 0)
-                flap_count = connection_down_count / 2
+                flap_count = int(connection_down_count / 2)
                 if up:
                     flap_count -= 1
                 if remote_as not in bgp_neighbors_detail[vrf_name].keys():
@@ -1008,9 +1011,9 @@ class IOSXRDriver(NetworkDriver):
 
         for arp_entry in result_tree.xpath('.//EntryTable/Entry'):
             interface = napalm_base.helpers.convert(
-                unicode, napalm_base.helpers.find_txt(arp_entry, './/InterfaceName'))
+                text_type, napalm_base.helpers.find_txt(arp_entry, './/InterfaceName'))
             ip = napalm_base.helpers.convert(
-                unicode, napalm_base.helpers.find_txt(arp_entry, './/Address'))
+                text_type, napalm_base.helpers.find_txt(arp_entry, './/Address'))
             age = napalm_base.helpers.convert(float,
                 napalm_base.helpers.find_txt(arp_entry, './/Age'), 0.0)
             mac_raw = napalm_base.helpers.find_txt(arp_entry, './/HardwareAddress')
@@ -1123,13 +1126,14 @@ class IOSXRDriver(NetworkDriver):
         <IPV6Network></IPV6Network></Operational></Get>'
 
         # only one request
-        ipv4_ipv6_tree = ETREE.fromstring(self.device.make_rpc_call(rpc_command_ipv4_ipv6))
+        ipv4_ipv6_tree = ETREE.fromstring(
+            self.device.make_rpc_call(rpc_command_ipv4_ipv6))
 
         # parsing IPv4
         ipv4_xpath = './/IPV4Network/InterfaceTable/Interface'
         for interface in ipv4_ipv6_tree.xpath(ipv4_xpath):
             interface_name = napalm_base.helpers.convert(
-                unicode, napalm_base.helpers.find_txt(interface, 'Naming/InterfaceName'))
+                text_type, napalm_base.helpers.find_txt(interface, 'Naming/InterfaceName'))
             primary_ip = napalm_base.helpers.ip(napalm_base.helpers.find_txt(
                     interface, 'VRFTable/VRF/Detail/PrimaryAddress'))
             primary_prefix = napalm_base.helpers.convert(
@@ -1159,7 +1163,7 @@ class IOSXRDriver(NetworkDriver):
         )
         for interface in ipv4_ipv6_tree.xpath(ipv6_xpath):
             interface_name = napalm_base.helpers.convert(
-                unicode, napalm_base.helpers.find_txt(interface, 'Naming/InterfaceName'))
+                text_type, napalm_base.helpers.find_txt(interface, 'Naming/InterfaceName'))
             if interface_name not in interfaces_ip.keys():
                 interfaces_ip[interface_name] = {}
             if u'ipv6' not in interfaces_ip[interface_name].keys():
@@ -1239,7 +1243,7 @@ class IOSXRDriver(NetworkDriver):
 
         for route in routes_tree.xpath('.//Route'):
             route_protocol = napalm_base.helpers.convert(
-                unicode, napalm_base.helpers.find_txt(route, 'ProtocolName').upper())
+                text_type, napalm_base.helpers.find_txt(route, 'ProtocolName').upper())
             if route_protocol.lower() != protocol:
                 continue  # ignore routes learned via a different protocol
             route_details = {}
@@ -1251,7 +1255,7 @@ class IOSXRDriver(NetworkDriver):
             age = napalm_base.helpers.convert(
                 int, napalm_base.helpers.find_txt(route, 'RouteAge'))
             destination = napalm_base.helpers.convert(
-                unicode,
+                text_type,
                 '{prefix}/{length}'.format(
                     prefix=address,
                     length=length
@@ -1403,7 +1407,8 @@ class IOSXRDriver(NetworkDriver):
 
         sla_config_rpc_command = '<Get><Configuration><IPSLA></IPSLA></Configuration></Get>'
 
-        sla_config_result_tree = ETREE.fromstring(self.device.make_rpc_call(sla_config_rpc_command))
+        sla_config_result_tree = ETREE.fromstring(
+            self.device.make_rpc_call(sla_config_rpc_command))
 
         for probe in sla_config_result_tree.xpath('.//Definition'):
             probe_name = napalm_base.helpers.find_txt(probe, 'Naming/OperationID')
@@ -1445,14 +1450,15 @@ class IOSXRDriver(NetworkDriver):
 
         sla_results_rpc_command = '<Get><Operational><IPSLA></IPSLA></Operational></Get>'
 
-        sla_results_tree = ETREE.fromstring(self.device.make_rpc_call(sla_results_rpc_command))
+        sla_results_tree = ETREE.fromstring(
+            self.device.make_rpc_call(sla_results_rpc_command))
 
         probes_config = self.get_probes_config()  # need to retrieve also the configuration
         # source and tag/test_name not provided
 
         for probe in sla_results_tree.xpath('.//Operation'):
             probe_name = napalm_base.helpers.find_txt(probe, 'Naming/OperationID')
-            test_name = probes_config.get(probe_name).keys()[0]
+            test_name = list(probes_config.get(probe_name).keys())[0]
             target = napalm_base.helpers.find_txt(
                 probe, 'History/Target/LifeTable/Life/BucketTable/Bucket[0]/TargetAddress\
                 /IPv4AddressTarget')
@@ -1626,9 +1632,9 @@ class IOSXRDriver(NetworkDriver):
                     last_probe_host_name = last_probe_ip_address
                 last_hop_dict['probes'][last_probe_index] = {
                     'ip_address': napalm_base.helpers.convert(
-                        unicode, last_probe_ip_address),
+                        text_type, last_probe_ip_address),
                     'host_name': napalm_base.helpers.convert(
-                        unicode, last_probe_host_name),
+                        text_type, last_probe_host_name),
                     'rtt': timeout * 1000.0
                 }
                 continue

--- a/napalm_iosxr/iosxr.py
+++ b/napalm_iosxr/iosxr.py
@@ -68,7 +68,7 @@ class IOSXRDriver(NetworkDriver):
         try:
             self.device.open()
         except ConnectError as conn_err:
-            raise ConnectionException(conn_err.message)
+            raise ConnectionException(conn_err.args[0])
 
     def close(self):
         self.device.close()
@@ -89,7 +89,7 @@ class IOSXRDriver(NetworkDriver):
         except InvalidInputError as e:
             self.pending_changes = False
             self.replace = False
-            raise ReplaceConfigException(e.message)
+            raise ReplaceConfigException(e.args[0])
 
     def load_merge_candidate(self, filename=None, config=None):
         self.pending_changes = True
@@ -102,7 +102,7 @@ class IOSXRDriver(NetworkDriver):
         except InvalidInputError as e:
             self.pending_changes = False
             self.replace = False
-            raise MergeConfigException(e.message)
+            raise MergeConfigException(e.args[0])
 
     def compare_config(self):
         if not self.pending_changes:

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -55,11 +55,14 @@ class FakeIOSXRDevice(BaseTestDouble):
     def close(self):
         pass
 
-    def make_rpc_call(self, rpc_call):
+    def make_rpc_call(self, rpc_call, encoded=True):
         filename = '{}.txt'.format(self.sanitize_text(rpc_call))
         full_path = self.find_file(filename)
         result = self.read_txt_file(full_path)
-        return result
+        if encoded:
+            return str.encode(result)
+        else:
+            return result
 
     def show_lldp_neighbors(self):
         filename = 'show_lldp_neighbors.txt'
@@ -71,4 +74,4 @@ class FakeIOSXRDevice(BaseTestDouble):
         rpc_request = '<CLI><Configuration>{show_command}</Configuration></CLI>'.format(
             show_command=show_command
         )
-        return self.make_rpc_call(rpc_request)
+        return self.make_rpc_call(rpc_request, encoded=False)

--- a/test/unit/mocked_data/test_get_facts/normal/expected_result.json
+++ b/test/unit/mocked_data/test_get_facts/normal/expected_result.json
@@ -5,6 +5,6 @@
 	"fqdn": "edge01.tab01",
 	"os_version": "5.3.1",
 	"serial_number": "FOX1717PLM4",
-	"interface_list": ["TenGigE0/0/0/14", "TenGigE0/0/0/24", "TenGigE0/0/0/13"],
+	"interface_list": ["TenGigE0/0/0/13", "TenGigE0/0/0/14", "TenGigE0/0/0/24"],
 	"model": "ASR-9904-AC"
 }


### PR DESCRIPTION
I started doing some work on Python 3 support. This PR depends on Python 3 support in pyIOSXR which and the tests will fail until [this PR](https://github.com/fooelisa/pyiosxr/pull/35) gets merged.

However there's an issue when running the tests. Some times it works like this:

```
================================================================================= test session starts =================================================================================
platform darwin -- Python 3.5.2, pytest-3.0.5, py-1.4.31, pluggy-0.4.0 -- /Users/patrick/.virtualenvs/py3-napalm/bin/python3.5
cachedir: .cache
rootdir: /Users/patrick/src/forks/napalm-iosxr, inifile: setup.cfg
plugins: pylama-7.3.1, cov-2.4.0, json-0.4.0, pythonpath-0.7.1
collected 28 items

test/unit/test_getters.py::TestGetter::test_is_alive[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_facts[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_interfaces[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_lldp_neighbors[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_interfaces_counters[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_environment[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_bgp_neighbors[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_lldp_neighbors_detail[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_bgp_config[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_bgp_neighbors_detail[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_arp_table[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_ntp_peers[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_ntp_servers[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_ntp_stats[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_interfaces_ip[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_mac_address_table[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_route_to[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_snmp_information[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_probes_config[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_probes_results[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_ping[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py SKIPPED
test/unit/test_getters.py::TestGetter::test_traceroute[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_users[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_optics[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py SKIPPED
test/unit/test_getters.py::TestGetter::test_get_config[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_config_filtered[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_network_instances[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py SKIPPED
test/unit/test_getters.py::TestGetter::test_get_firewall_policies[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py SKIPPED

------------------------------------------------------ generated json report: /Users/patrick/src/forks/napalm-iosxr/report.json -------------------------------------------------------


======================================================================== 24 passed, 4 skipped in 0.80 seconds =========================================================================

patrick at ns2803m in ~/src/forks/napalm-iosxr (python3●) (py3-napalm)
$
```

Other times one of the test fails:

```
patrick at ns2803m in ~/src/forks/napalm-iosxr (python3●) (py3-napalm)
$ py.test --cov-report= --cov=napalm_iosxr test/
================================================================================= test session starts =================================================================================
platform darwin -- Python 3.5.2, pytest-3.0.5, py-1.4.31, pluggy-0.4.0 -- /Users/patrick/.virtualenvs/py3-napalm/bin/python3.5
cachedir: .cache
rootdir: /Users/patrick/src/forks/napalm-iosxr, inifile: setup.cfg
plugins: pylama-7.3.1, cov-2.4.0, json-0.4.0, pythonpath-0.7.1
collected 28 items

test/unit/test_getters.py::TestGetter::test_is_alive[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_facts[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_interfaces[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_lldp_neighbors[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_interfaces_counters[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_environment[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_bgp_neighbors[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_lldp_neighbors_detail[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_bgp_config[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_bgp_neighbors_detail[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py FAILED
test/unit/test_getters.py::TestGetter::test_get_arp_table[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_ntp_peers[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_ntp_servers[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_ntp_stats[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_interfaces_ip[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_mac_address_table[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_route_to[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_snmp_information[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_probes_config[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_probes_results[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_ping[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py SKIPPED
test/unit/test_getters.py::TestGetter::test_traceroute[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_users[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_optics[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py SKIPPED
test/unit/test_getters.py::TestGetter::test_get_config[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_config_filtered[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_network_instances[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py SKIPPED
test/unit/test_getters.py::TestGetter::test_get_firewall_policies[normal] <- ../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py SKIPPED

------------------------------------------------------ generated json report: /Users/patrick/src/forks/napalm-iosxr/report.json -------------------------------------------------------


====================================================================================== FAILURES =======================================================================================
__________________________________________________________________ TestGetter.test_get_bgp_neighbors_detail[normal] ___________________________________________________________________

self = <test.unit.test_getters.TestGetter object at 0x105bcf0b8>, test_case = 'normal'

    @wrap_test_cases
    def test_get_bgp_neighbors_detail(self, test_case):
        """Test get_bgp_neighbors_detail."""
>       get_bgp_neighbors_detail = self.device.get_bgp_neighbors_detail()

../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/getters.py:226:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
napalm_iosxr/iosxr.py:855: in get_bgp_neighbors_detail
    str.encode(self.device.make_rpc_call(bgp_neighbors_vrf_all_rpc)))
test/unit/conftest.py:60: in make_rpc_call
    full_path = self.find_file(filename)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <test.unit.conftest.FakeIOSXRDevice object at 0x105bb8be0>
filename = '_Get__Operational__BGP__InstanceTable__Instance__Naming__________InstanceName_default__InstanceName___Naming__InstanceActive__VRFTable__VRF__Naming_te.txt'

    def find_file(self, filename):
        """Find the necessary file for the given test case."""
        # Find base_dir of submodule
        module_dir = os.path.dirname(sys.modules[self.__module__].__file__)

        full_path = os.path.join(module_dir, 'mocked_data',
                                 self.current_test, self.current_test_case, filename)

        if os.path.exists(full_path):
            return full_path
        else:
>           raise IOError("Couldn't find file with mocked data: {}".format(full_path))
E           OSError: Couldn't find file with mocked data: /Users/patrick/src/forks/napalm-iosxr/test/unit/mocked_data/test_get_bgp_neighbors_detail/normal/_Get__Operational__BGP__InstanceTable__Instance__Naming__________InstanceName_default__InstanceName___Naming__InstanceActive__VRFTable__VRF__Naming_te.txt

../../../.virtualenvs/py3-napalm/lib/python3.5/site-packages/napalm_base/test/double.py:32: OSError
=================================================================== 1 failed, 23 passed, 4 skipped in 0.91 seconds ====================================================================
```

I haven't try to figure out what happens, but based on the results I'm getting I would guess that the `get_bgp_neighbors_detail()` function return a dict. Sometimes it looks for the file _Get__Operational__BGP__InstanceTable__Instance__Naming__________InstanceName_default__InstanceName___Naming__InstanceActive__VRFTable__VRF__Naming_te.txt but other times it doesn't. So it feels like an ordering issue in a dictionary. @mirceaulinic, do you have any idea what is happening?