### PR TITLE
More optional args

### DIFF
--- a/napalm_iosxr/iosxr.py
+++ b/napalm_iosxr/iosxr.py
@@ -59,7 +59,7 @@ class IOSXRDriver(NetworkDriver):
         if optional_args is None:
             optional_args = {}
         self.port = optional_args.get('port', 22)
-        self.lock_on_connect = optional_args.get('config_lock', True)
+        self.lock_on_connect = optional_args.get('config_lock', False)
         # Netmiko possible arguments
         netmiko_argument_map = {
             'verbose': False,

--- a/napalm_iosxr/iosxr.py
+++ b/napalm_iosxr/iosxr.py
@@ -62,6 +62,7 @@ class IOSXRDriver(NetworkDriver):
         self.lock_on_connect = optional_args.get('config_lock', False)
         # Netmiko possible arguments
         netmiko_argument_map = {
+            'keepalive': 30,
             'verbose': False,
             'global_delay_factor': 1,
             'use_keys': False,
@@ -70,7 +71,7 @@ class IOSXRDriver(NetworkDriver):
             'system_host_keys': False,
             'alt_host_keys': False,
             'alt_key_file': '',
-            'ssh_config_file': None,
+            'ssh_config_file': None
         }
         fields = netmiko_version.split('.')
         fields = [int(x) for x in fields]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 napalm-base>=0.18.0
-pyIOSXR >= 0.20
+pyIOSXR>=0.50
 netaddr


### PR DESCRIPTION
Borrowed some code from napalm-ios. Probably on the longer run we may have this under the upcoming napalm-netmiko driver.
Depends on pyiosxr 0.50 (not released yet) so the tests will fail right now.