### PR TITLE
Use 'global' outer key

### DIFF
--- a/napalm_iosxr/iosxr.py
+++ b/napalm_iosxr/iosxr.py
@@ -1055,7 +1055,7 @@ class IOSXRDriver(NetworkDriver):
                     'advertised_prefix_count': advertised_prefix_count,
                     'flap_count': flap_count
                 })
-
+        bgp_neighbors_detail['global'] = bgp_neighbors_detail.pop('default')
         return bgp_neighbors_detail
 
     def get_arp_table(self):

--- a/test/unit/mocked_data/test_get_bgp_neighbors_detail/normal/expected_result.json
+++ b/test/unit/mocked_data/test_get_bgp_neighbors_detail/normal/expected_result.json
@@ -1,5 +1,5 @@
 {
-	"default": {
+	"global": {
 		"7777": [{
 			"suppress_4byte_as": false,
 			"local_as_prepend": true,


### PR DESCRIPTION
The outer key for get_bgp_neighbors_detail used to be default,
although the documentation says it should be global.
This is a breaking change, hence it will be included in a major release.

Solves #115