### PR TITLE
Avoid installing the test/ directory & files as a package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ reqs = [str(ir.req) for ir in install_reqs]
 setup(
     name="napalm-iosxr",
     version="0.5.0",
-    packages=find_packages(),
+    packages=find_packages(exclude=["test", "test.*"]),
     author="David Barroso, Mircea Ulinic",
     author_email="dbarrosop@dravetech.com, mircea@cloudflare.com",
     description="Network Automation and Programmability Abstraction Layer with Multivendor support",


### PR DESCRIPTION
This fix is mirroring the fix for issue 91 in napalm-nxos.

