### PR TITLE
get_bgp_config: Have prefix limit check for lower case AF

### DIFF
--- a/napalm_iosxr/iosxr.py
+++ b/napalm_iosxr/iosxr.py
@@ -723,9 +723,9 @@ class IOSXRDriver(NetworkDriver):
             inet = False
             inet6 = False
             preifx_type = 'inet'
-            if 'IPV4' in af_table:
+            if 'ipv4' in af_table.lower():
                 inet = True
-            if 'IPv6' in af_table:
+            if 'ipv6' in af_table.lower():
                 inet6 = True
                 preifx_type = 'inet6'
             if inet or inet6:

--- a/test/unit/mocked_data/test_get_bgp_config/mixed_with_without_groups/expected_result.json
+++ b/test/unit/mocked_data/test_get_bgp_config/mixed_with_without_groups/expected_result.json
@@ -1,82 +1,112 @@
 {
-	"RR": {
-		"neighbors": {
-			"10.255.255.12": {
-				"local_address": "",
-				"export_policy": "",
-				"route_reflector_client": false,
-				"remote_as": 0,
-				"authentication_key": "",
-				"import_policy": "RP-SPECIAL-SNOWFLAKE-IN",
-				"nhs": false,
-				"prefix_limit": {},
-				"local_as": 0,
-				"description": ""
-			},
-			"10.255.255.3": {
-				"local_address": "",
-				"export_policy": "",
-				"route_reflector_client": false,
-				"remote_as": 0,
-				"authentication_key": "",
-				"import_policy": "",
-				"nhs": false,
-				"prefix_limit": {},
-				"local_as": 0,
-				"description": ""
-			}
-		},
-		"remote_as": 65900,
-		"multipath": false,
-		"export_policy": "",
-		"prefix_limit": {},
-		"description": "",
-		"local_address": "",
-		"apply_groups": [],
-		"remove_private_as": true,
-		"import_policy": "RP-RR-IN",
-		"type": "external",
-		"local_as": 0,
-		"multihop_ttl": 0
-	},
-	"_": {
-		"neighbors": {
-			"10.255.255.2": {
-				"local_address": "",
-				"export_policy": "pass-all",
-				"route_reflector_client": false,
-				"remote_as": 65900,
-				"authentication_key": "",
-				"import_policy": "pass-all",
-				"nhs": false,
-				"prefix_limit": {},
-				"local_as": 0,
-				"description": ""
-			},
-			"10.255.255.220": {
-				"local_address": "",
-				"export_policy": "pass-all",
-				"route_reflector_client": false,
-				"remote_as": 65900,
-				"authentication_key": "",
-				"import_policy": "pass-all",
-				"nhs": false,
-				"prefix_limit": {},
-				"local_as": 0,
-				"description": ""
-			}
-		},
-		"remote_as": 0,
-		"multipath": false,
-		"export_policy": "",
-		"prefix_limit": {},
-		"description": "",
-		"local_address": "",
-		"apply_groups": [],
-		"remove_private_as": false,
-		"import_policy": "",
-		"type": "",
-		"local_as": 0,
-		"multihop_ttl": 0
-	}
+  "_": {
+    "remote_as": 0,
+    "neighbors": {
+      "10.255.255.220": {
+        "remote_as": 65900,
+        "export_policy": "pass-all",
+        "description": "",
+        "route_reflector_client": false,
+        "nhs": false,
+        "local_as": 0,
+        "import_policy": "pass-all",
+        "local_address": "",
+        "prefix_limit": {
+          "inet": {
+            "unicast": {
+              "limit": 0,
+              "teardown": {
+                "threshold": 0,
+                "timeout": 0
+              }
+            }
+          }
+        },
+        "authentication_key": ""
+      },
+      "10.255.255.2": {
+        "remote_as": 65900,
+        "export_policy": "pass-all",
+        "description": "",
+        "route_reflector_client": false,
+        "nhs": false,
+        "local_as": 0,
+        "import_policy": "pass-all",
+        "local_address": "",
+        "prefix_limit": {
+          "inet": {
+            "unicast": {
+              "limit": 0,
+              "teardown": {
+                "threshold": 0,
+                "timeout": 0
+              }
+            }
+          }
+        },
+        "authentication_key": ""
+      }
+    },
+    "multihop_ttl": 0,
+    "import_policy": "",
+    "local_address": "",
+    "type": "",
+    "remove_private_as": false,
+    "description": "",
+    "export_policy": "",
+    "local_as": 0,
+    "apply_groups": [],
+    "multipath": false,
+    "prefix_limit": {}
+  },
+  "RR": {
+    "remote_as": 65900,
+    "neighbors": {
+      "10.255.255.12": {
+        "remote_as": 0,
+        "export_policy": "",
+        "description": "",
+        "route_reflector_client": false,
+        "nhs": false,
+        "local_as": 0,
+        "import_policy": "RP-SPECIAL-SNOWFLAKE-IN",
+        "local_address": "",
+        "prefix_limit": {
+          "inet": {
+            "unicast": {
+              "limit": 0,
+              "teardown": {
+                "threshold": 0,
+                "timeout": 0
+              }
+            }
+          }
+        },
+        "authentication_key": ""
+      },
+      "10.255.255.3": {
+        "remote_as": 0,
+        "export_policy": "",
+        "description": "",
+        "route_reflector_client": false,
+        "nhs": false,
+        "local_as": 0,
+        "import_policy": "",
+        "local_address": "",
+        "prefix_limit": {},
+        "authentication_key": ""
+      }
+    },
+    "multihop_ttl": 0,
+    "import_policy": "RP-RR-IN",
+    "local_address": "",
+    "type": "external",
+    "remove_private_as": true,
+    "description": "",
+    "export_policy": "",
+    "local_as": 0,
+    "apply_groups": [],
+    "multipath": false,
+    "prefix_limit": {}
+  }
 }

--- a/test/unit/mocked_data/test_get_bgp_config/normal/expected_result.json
+++ b/test/unit/mocked_data/test_get_bgp_config/normal/expected_result.json
@@ -1,54 +1,84 @@
 {
-	"4-public-anycast-peers": {
-		"neighbors": {
-			"192.168.50.5": {
-				"export_policy": "",
-				"remote_as": 9009,
-				"description": "M247 Ltd [UK Hosting ANYCAST]",
-				"prefix_limit": {},
-				"local_as": 0,
-				"nhs": false,
-				"route_reflector_client": false,
-				"local_address": "",
-				"authentication_key": "",
-				"import_policy": ""
-			},
-			"192.168.20.3": {
-				"export_policy": "",
-				"remote_as": 9050,
-				"description": "Telekom Romania [RO ISP ANYCAST]",
-				"prefix_limit": {},
-				"local_as": 0,
-				"nhs": false,
-				"route_reflector_client": false,
-				"local_address": "",
-				"authentication_key": "",
-				"import_policy": ""
-			},
-			"172.17.17.50": {
-				"export_policy": "",
-				"remote_as": 48161,
-				"description": "NextGen [RO ISP ANYCAST]",
-				"prefix_limit": {},
-				"local_as": 0,
-				"nhs": false,
-				"route_reflector_client": false,
-				"local_address": "",
-				"authentication_key": "",
-				"import_policy": ""
-			}
-		},
-		"export_policy": "4-public-anycast-peers-out",
-		"prefix_limit": {},
-		"description": "",
-		"local_address": "",
-		"local_as": 0,
-		"multihop_ttl": 0,
-		"apply_groups": [],
-		"remote_as": 0,
-		"remove_private_as": true,
-		"multipath": false,
-		"type": "external",
-		"import_policy": "4-public-anycast-peers-in"
-	}
+  "4-public-anycast-peers": {
+    "local_as": 0,
+    "remove_private_as": true,
+    "import_policy": "4-public-anycast-peers-in",
+    "multihop_ttl": 0,
+    "neighbors": {
+      "192.168.20.3": {
+        "export_policy": "",
+        "local_as": 0,
+        "prefix_limit": {
+          "inet": {
+            "unicast": {
+              "teardown": {
+                "timeout": 0,
+                "threshold": 75
+              },
+              "limit": 5000
+            }
+          }
+        },
+        "remote_as": 9050,
+        "import_policy": "",
+        "nhs": false,
+        "authentication_key": "",
+        "local_address": "",
+        "description": "Telekom Romania [RO ISP ANYCAST]",
+        "route_reflector_client": false
+      },
+      "172.17.17.50": {
+        "export_policy": "",
+        "local_as": 0,
+        "prefix_limit": {
+          "inet": {
+            "unicast": {
+              "teardown": {
+                "timeout": 0,
+                "threshold": 75
+              },
+              "limit": 500
+            }
+          }
+        },
+        "remote_as": 48161,
+        "import_policy": "",
+        "nhs": false,
+        "authentication_key": "",
+        "local_address": "",
+        "description": "NextGen [RO ISP ANYCAST]",
+        "route_reflector_client": false
+      },
+      "192.168.50.5": {
+        "export_policy": "",
+        "local_as": 0,
+        "prefix_limit": {
+          "inet": {
+            "unicast": {
+              "teardown": {
+                "timeout": 0,
+                "threshold": 75
+              },
+              "limit": 1000
+            }
+          }
+        },
+        "remote_as": 9009,
+        "import_policy": "",
+        "nhs": false,
+        "authentication_key": "",
+        "local_address": "",
+        "description": "M247 Ltd [UK Hosting ANYCAST]",
+        "route_reflector_client": false
+      }
+    },
+    "multipath": false,
+    "export_policy": "4-public-anycast-peers-out",
+    "type": "external",
+    "apply_groups": [],
+    "remote_as": 0,
+    "prefix_limit": {},
+    "description": "",
+    "local_address": ""
+  }
 }

--- a/test/unit/mocked_data/test_get_bgp_config/peers_without_groups/expected_result.json
+++ b/test/unit/mocked_data/test_get_bgp_config/peers_without_groups/expected_result.json
@@ -1,42 +1,62 @@
 {
-	"_": {
-		"remote_as": 0,
-		"export_policy": "",
-		"import_policy": "",
-		"apply_groups": [],
-		"local_address": "",
-		"multihop_ttl": 0,
-		"remove_private_as": false,
-		"description": "",
-		"multipath": false,
-		"prefix_limit": {},
-		"type": "",
+  "_": {
+    "multipath": false,
+    "prefix_limit": {},
+    "description": "",
+    "type": "",
+    "import_policy": "",
+    "export_policy": "",
+    "local_address": "",
+    "remove_private_as": false,
+    "remote_as": 0,
+    "multihop_ttl": 0,
     "local_as": 0,
-		"neighbors": {
-			"10.255.255.2": {
-				"route_reflector_client": false,
-				"prefix_limit": {},
-				"nhs": false,
-				"import_policy": "pass-all",
-				"export_policy": "pass-all",
-				"authentication_key": "",
-				"remote_as": 65900,
-				"description": "",
-				"local_address": "",
-				"local_as": 0
-			},
-			"10.255.255.3": {
-				"route_reflector_client": false,
-				"prefix_limit": {},
-				"nhs": false,
-				"import_policy": "pass-all",
-				"export_policy": "pass-all",
-				"authentication_key": "",
-				"remote_as": 65900,
-				"description": "",
-				"local_address": "",
-				"local_as": 0
-			}
-		}
-	}
+    "apply_groups": [],
+    "neighbors": {
+      "10.255.255.2": {
+        "route_reflector_client": false,
+        "prefix_limit": {
+          "inet": {
+            "unicast": {
+              "teardown": {
+                "timeout": 0,
+                "threshold": 0
+              },
+              "limit": 0
+            }
+          }
+        },
+        "local_as": 0,
+        "description": "",
+        "local_address": "",
+        "import_policy": "pass-all",
+        "remote_as": 65900,
+        "export_policy": "pass-all",
+        "authentication_key": "",
+        "nhs": false
+      },
+      "10.255.255.3": {
+        "route_reflector_client": false,
+        "prefix_limit": {
+          "inet": {
+            "unicast": {
+              "teardown": {
+                "timeout": 0,
+                "threshold": 0
+              },
+              "limit": 0
+            }
+          }
+        },
+        "local_as": 0,
+        "description": "",
+        "local_address": "",
+        "import_policy": "pass-all",
+        "remote_as": 65900,
+        "export_policy": "pass-all",
+        "authentication_key": "",
+        "nhs": false
+      }
+    }
+  }
 }


### PR DESCRIPTION
Currently we check the address family using `IPV4` for inet addesses,
however the IOS-XR version `6.1.2` gives the family as `IPv4Unicast`.
Therefore to catch any variations we should check both as lowercase.

<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>
