### PR TITLE
Bump napalm-base for napalm_base.constants module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-napalm-base>=0.18.0
+napalm-base>=0.23.0
 pyIOSXR>=0.51
 netaddr


### PR DESCRIPTION
Fixes bug in requirements.txt which would appear when upgrading napalm-iosxr but not napalm-base.

I haven't done a comprehensive test, but 0.23.0 seems to be the earliest supported version of napalm-base.

```
>>> import napalm_iosxr
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "napalm_iosxr/__init__.py", line 22, in <module>
    from napalm_iosxr.iosxr import IOSXRDriver  # noqa
  File "napalm_iosxr/iosxr.py", line 39, in <module>
    import napalm_iosxr.constants as C
  File "napalm_iosxr/constants.py", line 5, in <module>
    from napalm_base.constants import *  # noqa
ImportError: No module named constants
>>>

Successfully installed napalm-base-0.20.0
(iosxr-req)~/src/forks/napalm-iosxr (develop ✔) ᐅ python
Python 2.7.12 (default, Dec  5 2016, 11:55:02)
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import napalm_iosxr
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "napalm_iosxr/__init__.py", line 22, in <module>
    from napalm_iosxr.iosxr import IOSXRDriver  # noqa
  File "napalm_iosxr/iosxr.py", line 49, in <module>
    class IOSXRDriver(NetworkDriver):
  File "napalm_iosxr/iosxr.py", line 1633, in IOSXRDriver
    source=C.TRACEROUTE_SOURCE,
AttributeError: 'module' object has no attribute 'TRACEROUTE_SOURCE'
>>>

Successfully installed napalm-base-0.20.4
(iosxr-req)~/src/forks/napalm-iosxr (develop ✔) ᐅ python
Python 2.7.12 (default, Dec  5 2016, 11:55:02)
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import napalm_iosxr
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "napalm_iosxr/__init__.py", line 22, in <module>
    from napalm_iosxr.iosxr import IOSXRDriver  # noqa
  File "napalm_iosxr/iosxr.py", line 49, in <module>
    class IOSXRDriver(NetworkDriver):
  File "napalm_iosxr/iosxr.py", line 1636, in IOSXRDriver
    vrf=C.TRACEROUTE_VRF):
AttributeError: 'module' object has no attribute 'TRACEROUTE_VRF'
>>>

Successfully installed napalm-base-0.23.0
(iosxr-req)~/src/forks/napalm-iosxr (develop ✔) ᐅ python
Python 2.7.12 (default, Dec  5 2016, 11:55:02)
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import napalm_iosxr
>>> exit()
```