### PR TITLE
Added interfaces parsing

### DIFF
--- a/napalm_iosxr_ssh/iosxr_ssh.py
+++ b/napalm_iosxr_ssh/iosxr_ssh.py
@@ -289,3 +289,25 @@ class IOSXRSSHDriver(NetworkDriver):
             response = self._send_command(command)
             cli_output[command] = response
         return cli_output
+
+    def get_interfaces(self):
+
+        interfaces = {}
+
+        INTERFACE_DEFAULTS = {
+            'is_enabled': False,
+            'is_up': False,
+            'mac_address': u'',
+            'description': u'',
+            'speed': -1,
+            'last_flapped': -1.0
+        }
+
+        interfaces_command = 'show interfaces'
+
+        interfaces_ssh_reply = self._send_command(interfaces_command)
+
+        t = napalm_base.helpers.textfsm_extractor(self, "cisco_xr_show_interfaces", interfaces_ssh_reply)
+        t = napalm_base.helpers.textfsm_extractor(self, "cisco_xr_show_interfaces_admin", interfaces_ssh_reply)
+
+        return interfaces

--- a/napalm_iosxr_ssh/utils/textfsm_templates/cisco_xr_show_interfaces.tpl
+++ b/napalm_iosxr_ssh/utils/textfsm_templates/cisco_xr_show_interfaces.tpl
@@ -1,0 +1,23 @@
+Value Required INTERFACE (\S+)
+Value LINK_STATUS (\w+)
+Value ADMIN_STATE (\S+)
+Value HARDWARE_TYPE (\w+)
+Value ADDRESS ([a-zA-Z0-9]+.[a-zA-Z0-9]+.[a-zA-Z0-9]+)
+Value BIA ([a-zA-Z0-9]+.[a-zA-Z0-9]+.[a-zA-Z0-9]+)
+Value DESCRIPTION (.*)
+Value IP_ADDRESS (\d+\.\d+\.\d+\.\d+\/\d+)
+Value MTU (\d+)
+Value DUPLEX (.+?)
+Value SPEED (.+?)
+Value BANDWIDTH (\d+\s+\w+)
+Value ENCAPSULATION (\w+)
+
+Start
+  ^${INTERFACE}\sis\s+${LINK_STATUS},\s+line\sprotocol\sis\s+${ADMIN_STATE}
+  ^\s+Hardware\s+is\s+${HARDWARE_TYPE}(\s+)?(Ethernet)?(,)?(\s+address\s+is\s+${ADDRESS}\s+\(bia\s+${BIA})?
+  ^\s+Description:\s+${DESCRIPTION}
+  ^\s+Internet\s+Address\s+is\s+${IP_ADDRESS}
+  ^\s+MTU\s+${MTU}.*BW\s+${BANDWIDTH}
+  ^\s+${DUPLEX}, ${SPEED},.+link 
+  ^\s+Encapsulation\s+${ENCAPSULATION}
+  ^\s+Last -> Record

--- a/napalm_iosxr_ssh/utils/textfsm_templates/cisco_xr_show_interfaces_admin.tpl
+++ b/napalm_iosxr_ssh/utils/textfsm_templates/cisco_xr_show_interfaces_admin.tpl
@@ -1,0 +1,23 @@
+Value Required INTERFACE (\S+)
+Value LINK_STATUS (\w+)
+Value ADMIN_STATE (\S+)
+Value HARDWARE_TYPE (\w+)
+Value ADDRESS ([a-zA-Z0-9]+.[a-zA-Z0-9]+.[a-zA-Z0-9]+)
+Value BIA ([a-zA-Z0-9]+.[a-zA-Z0-9]+.[a-zA-Z0-9]+)
+Value DESCRIPTION (.*)
+Value IP_ADDRESS (\d+\.\d+\.\d+\.\d+\/\d+)
+Value MTU (\d+)
+Value DUPLEX (.+?)
+Value SPEED (.+?)
+Value BANDWIDTH (\d+\s+\w+)
+Value ENCAPSULATION (\w+)
+
+Start
+  ^${INTERFACE}\sis.+\s${LINK_STATUS},\s+line\sprotocol\sis.+\s+${ADMIN_STATE}
+  ^\s+Hardware\s+is\s+${HARDWARE_TYPE}(\s+)?(Ethernet)?(,)?(\s+address\s+is\s+${ADDRESS}\s+\(bia\s+${BIA})?
+  ^\s+Description:\s+${DESCRIPTION}
+  ^\s+Internet\s+Address\s+is\s+${IP_ADDRESS}
+  ^\s+MTU\s+${MTU}.*BW\s+${BANDWIDTH}
+  ^\s+${DUPLEX}, ${SPEED},.+link 
+  ^\s+Encapsulation\s+${ENCAPSULATION}
+  ^\s+Last -> Record


### PR DESCRIPTION
Added interfaces parsing, using FSM templates at the moment.

Can be tested the following way:
```
import pprint
from napalm_base import get_network_driver
d = get_network_driver('iosxr_ssh')
j = d('127.0.0.1', 'user', 'pass', optional_args = {'port':22})
j.open()
pprint(j.get_interfaces())
j.close()```