### PR TITLE
Fix for https://github.com/napalm-automation/napalm-iosxr/issues/104.

### DIFF
--- a/napalm_iosxr/iosxr.py
+++ b/napalm_iosxr/iosxr.py
@@ -194,7 +194,10 @@ class IOSXRDriver(NetworkDriver):
         system_time_xpath = './/SystemTime/Uptime'
         platform_attr_xpath = './/RackTable/Rack/Attributes/BasicInfo'
         system_time_tree = facts_rpc_reply.xpath(system_time_xpath)[0]
-        platform_attr_tree = facts_rpc_reply.xpath(platform_attr_xpath)[0]
+        try:
+            platform_attr_tree = facts_rpc_reply.xpath(platform_attr_xpath)[0]
+        except IndexError:
+            platform_attr_tree = facts_rpc_reply.xpath(platform_attr_xpath)
 
         hostname = napalm_base.helpers.convert(
             text_type, napalm_base.helpers.find_txt(system_time_tree, 'Hostname'))


### PR DESCRIPTION
IOSXRv returns empty list for oper.PlatformInventory.RackTable.Rack.Attributes.BasicInfo, causing a fatal IndexError for the variable 'platform_attr_tree' in the 'get_facts' function. In fact, IOSXRv walkdata oper.PlatformInventory returns no data at all. As a result, only an interface_list will be returned and the remaining default facts values from the function will be used. This condition does NOT occur on physical IOSXR hosts. Therefore, original indexing needs to be preserved while the error condition is handled for IOSXRv hosts.

<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>
