### PR TITLE
use sisqo for device connection instead of netmiko

### DIFF
--- a/napalm_iosxr_ssh/iosxr_ssh.py
+++ b/napalm_iosxr_ssh/iosxr_ssh.py
@@ -13,19 +13,16 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
 from __future__ import unicode_literals
 
 # import stdlib
 import re
-import socket
 import difflib
 import logging
 
 # import third party lib
-from netmiko import ConnectHandler
-from netmiko import __version__ as netmiko_version
-from netmiko.ssh_exception import NetMikoTimeoutException
-from netmiko.ssh_exception import NetMikoAuthenticationException
+import sisqo
 
 # import NAPALM base
 import napalm_base.helpers
@@ -33,23 +30,20 @@ import napalm_iosxr.constants as C
 from napalm_base.base import NetworkDriver
 from napalm_base.utils import py23_compat
 from napalm_base.exceptions import ConnectionException
+from napalm_base.exceptions import LockError
 from napalm_base.exceptions import MergeConfigException
 from napalm_base.exceptions import ReplaceConfigException
 from napalm_base.exceptions import CommandTimeoutException
-from napalm_base.exceptions import LockError
-from napalm_base.exceptions import UnlockError
 from napalm_base.utils.py23_compat import text_type
 
 logging.basicConfig(filename='iosxr.log', level=logging.DEBUG)
 log = logging.getLogger(__file__)
 
+class IOSXRDriver(NetworkDriver):
 
-class IOSXRSSHDriver(NetworkDriver):
-    '''
-    SSH-based driver for IOS-XR.
-    '''
+    """IOS-XR driver class: inherits NetworkDriver from napalm_base."""
 
-    def __init__(self, hostname, username, password, timeout=60, optional_args=None):
+    def __init__(self, hostname, username, password, timeout=10, optional_args=None):
         self.hostname = hostname
         self.username = username
         self.password = password
@@ -57,43 +51,37 @@ class IOSXRSSHDriver(NetworkDriver):
         self.pending_changes = False
         self.replace = False
         if optional_args is None:
-            optional_args = {}
-        self.port = optional_args.get('port', 22)
-        self.lock_on_connect = optional_args.get('config_lock', False)
-        # Netmiko possible arguments
-        netmiko_argument_map = {
-            'keepalive': 30,
-            'verbose': False,
-            'global_delay_factor': 1,
-            'use_keys': False,
-            'key_file': None,
-            'ssh_strict': False,
-            'system_host_keys': False,
-            'alt_host_keys': False,
-            'alt_key_file': '',
-            'ssh_config_file': None
-        }
-        fields = netmiko_version.split('.')
-        fields = [int(x) for x in fields]
-        maj_ver, min_ver, bug_fix = fields
-        if maj_ver >= 2:
-            netmiko_argument_map['allow_agent'] = False
-        elif maj_ver == 1 and min_ver >= 1:
-            netmiko_argument_map['allow_agent'] = False
-        # Build dict of any optional Netmiko args
-        self.netmiko_optional_args = {}
-        for k, v in netmiko_argument_map.items():
-            try:
-                self.netmiko_optional_args[k] = optional_args[k]
-            except KeyError:
-                self.netmiko_optional_args[k] = v
+            self.optional_args = {}
+        self.port = self.optional_args.get('port', 22)
+        self.lock_on_connect = self.optional_args.get('config_lock', False)
+
+        self.device = sisqo.SSH(host=self.hostname,
+                            username=self.username,
+                            port = self.port,
+                            sshOptions=self.optional_args.get('ssh_options', None),
+                            timeout=self.timeout,
+                            logger=log)
+        self._in_config_mode = False
         log.debug('Creating a new instance of the NAPALM IOS-XR SSH driver')
         log.debug('Connecting to %s:%d as %s', self.hostname, self.port, self.username)
         log.debug('Optional args:')
-        log.debug(self.netmiko_optional_args)
-        self._in_config_mode = False
+        log.debug(self.optional_args)
 
-    def _send_command(self, command, configuration=False):
+
+    def open(self):
+        try:
+            self.device.authenticate(password=self.password)
+            if self.lock_on_connect:
+                self.lock()
+        except (sisqo.ssh.NotAuthenticatedError, sisqo.ssh.NotConnectedError) as err:
+            raise ConnectionException(err.args[0])
+
+
+    def close(self):
+            self.device.disconnect()
+
+
+    def _send_command(self, command, configuration=False, timeout=None):
         '''
         Helper to send the command and get the output.
         '''
@@ -102,40 +90,41 @@ class IOSXRSSHDriver(NetworkDriver):
             #   you can still execute arbitrary commands, not configuration-related.
             command = 'do {base_cmd}'.format(base_cmd=command)
         log.debug('Sending command: %s', command)
-        output = self.device.send_command_timing(command,
-                 delay_factor=self.netmiko_optional_args['global_delay_factor'],
-                 max_loops=self.timeout/self.netmiko_optional_args['global_delay_factor'])
+        if not self.is_alive()['is_alive']:
+            return
+        if timeout:
+            self.device.write(command, timeout=timeout)
+        else:
+            self.device.write(command)
+        output = self.device.read()
         log.debug('Received the output:')
         log.debug(output)
-        # The output has a newline after the command prompt
-        #   and another line with the timestamp.
+        # The output has a line with the timestamp.
         # e.g.:
-        #
         # Tue Jul 18 11:53:32.372 UTC
-        # For this reason, we need to strip the first two lines
-        #   and return only what comes after.
-        return '\n'.join(output.splitlines()[2:])
+        # For this reason, we need to strip the first line
+        return '\n'.join(output.splitlines()[1:])
 
     def lock(self):
         '''
         Lock the configuration DB.
         '''
         if self._in_config_mode:
-           log.info('Already in configuration mode')
-           return
+            log.info('Already in configuration mode')
+            return
         log.debug('Trying to lock the config DB')
         cfg_lock_out = self._send_command('configure exclusive')
         # Current Configuration Session  Line       User      Date                     Lock
         # 00000011-000a7139-0000008c     /dev/vty0  username  Tue Jul 18 11:02:16 2017 *
+        #
         # Can not enter exclusive mode. The Configuration Namespace is locked by another agent.
         cfg_lock_lines = cfg_lock_out.splitlines()
         if not cfg_lock_lines:
             # Nothing back, means everything was fine, config lock succeeded.
             self._in_config_mode = True
             return
-        if 'Can not enter exclusive mode' in cfg_lock_lines[-1] or\
-           'Cannot enter exclusive mode' in cfg_lock_lines[-1]:  # on the bloody IOS-XR >= 6.x
-            rgx = '([0-9a-z-]+)\s+([a-z0-9\/]+)\s+(\w+)\s+(.*)\s+(.?)'   # a beautiful regex
+        else:
+            rgx = '([0-9a-z-]+)\s+([a-z0-9\/]+)\s+(\w+)\s+(.*)\s+(.?)'  # a beautiful regex
             # to extract the timestamp and the username locking the config database
             lock_user = 'unknown'
             lock_ts = 'unknown'
@@ -147,8 +136,8 @@ class IOSXRSSHDriver(NetworkDriver):
                     continue
                 lock_user = rgx_res.group(3)
                 lock_ts = rgx_res.group(4)
-            lock_msg = 'Configuration DB locked by {usr} since {ts}'.format(usr=lock_user,
-                                                                            ts=lock_ts)
+            lock_msg = 'Can\'t lock db because {usr} has been in config' \
+                       ' mode since {ts}'.format(usr=lock_user, ts=lock_ts)
             log.error(lock_msg)
             raise LockError(lock_msg)
         self._in_config_mode = True
@@ -193,12 +182,15 @@ class IOSXRSSHDriver(NetworkDriver):
         '''
         Compare the candidate with the running configuration.
         '''
-        if self._in_config_mode and self.pending_changes:
+        if self._in_config_mode and self.pending_changes and not self.replace:
             show_candidate = self._send_command('show configuration merge', configuration=True)
             show_running = self._send_command('show running-config', configuration=True)
             diff = difflib.unified_diff(show_running.splitlines(1)[2:-2],
                                         show_candidate.splitlines(1)[2:-2])
             return ''.join([line.replace('\r', '') for line in diff])
+        elif self._in_config_mode and self.pending_changes and self.replace:
+            diff = self._send_command('show configuration changes diff', configuration=True)
+            return diff
         return ''
 
     def discard_config(self):
@@ -208,8 +200,8 @@ class IOSXRSSHDriver(NetworkDriver):
         log.debug('Discarding the candidate config')
         if self._in_config_mode:
             discarding = self._send_command('abort', configuration=True)
-            # When executing abort, it also quites the configuration mode.
-            self.unlock()
+            # When executing abort, it also quits the configuration mode.
+            self._in_config_mode = False
 
     def commit_config(self):
         '''
@@ -218,55 +210,37 @@ class IOSXRSSHDriver(NetworkDriver):
         log.debug('Committing')
         if self._in_config_mode and self.pending_changes:
             commit_cmd = 'commit {replace} save-running filename disk0:rollback-0'.format(
-                         replace='replace' if self.replace else '')
-            committing = self._send_command(commit_cmd, configuration=True)
-            if 'This could be a few minutes if your config is large. Confirm?' in committing:
+                replace='replace' if self.replace else '')
+            committing = self._send_command(commit_cmd, configuration=True, timeout=5)
+            if 'This commit will replace' in committing:
+                log.debug('Confirming commit replace')
+                confirming = self._send_command('yes', configuration=True)
+            elif 'This could be a few minutes if your config is large. Confirm?' in committing:
                 log.debug('Confirming file copy')
-                confirming = self._send_command('\n', configuration=True)
+                confirming = self._send_command('', configuration=True)
             log.debug('Exiting config mode')
-            exiting = self._send_command('exit', configuration=True)
             self.unlock()
 
     def unlock(self):
         '''
-        Unlock the configuration DB.
+        Unlock the configuration DB by exiting config mode.
         '''
         log.debug('Unlocking the config DB')
         self.pending_changes = False
         self.replace = False
-        if not self.lock_on_connect:
+        if self.lock_on_connect or not self._in_config_mode:
+            return
+        else:
+            self._send_command('abort', configuration=True)
             self._in_config_mode = False
-
-    def open(self):
-        '''
-        Open the connection with the device.
-        '''
-        try:
-            self.device = ConnectHandler(device_type='cisco_xr',
-                                         ip=self.hostname,
-                                         port=self.port,
-                                         username=self.username,
-                                         password=self.password,
-                                         **self.netmiko_optional_args)
-            self.device.timeout = self.timeout
-            if self.lock_on_connect:
-                self.lock()
-        except NetMikoTimeoutException as t_err:
-            raise ConnectionException(t_err.args[0])
-        except NetMikoAuthenticationException as au_err:
-            raise ConnectionException(au_err.args[0])
-
-    def close(self):
-        if hasattr(self.device, 'remote_conn'):
-            self.device.remote_conn.close()
 
     def is_alive(self):
         null = chr(0)
         try:
             # Try sending ASCII null byte to maintain
             #   the connection alive
-            self.device.send_command(null)
-        except (socket.error, EOFError):
+            self._send_command(null)
+        except (sisqo.ssh.NotConnectedError, sisqo.ssh.NotAuthenticatedError):
             # If unable to send, we can tell for sure
             #   that the connection is unusable,
             #   hence return False.
@@ -274,7 +248,7 @@ class IOSXRSSHDriver(NetworkDriver):
                 'is_alive': False
             }
         return {
-            'is_alive': self.device.remote_conn.transport.is_active()
+            'is_alive': True
         }
 
     def cli(self, commands):
@@ -290,24 +264,46 @@ class IOSXRSSHDriver(NetworkDriver):
             cli_output[command] = response
         return cli_output
 
-    def get_interfaces(self):
 
-        interfaces = {}
+    def get_facts(self):
 
-        INTERFACE_DEFAULTS = {
-            'is_enabled': False,
-            'is_up': False,
-            'mac_address': u'',
-            'description': u'',
-            'speed': -1,
-            'last_flapped': -1.0
+        facts = {
+            'vendor': u'Cisco',
+            'os_version': u'',
+            'hostname': u'',
+            'uptime': -1,
+            'serial_number': u'',
+            'fqdn': u'',
+            'model': u'',
+            'interface_list': []
         }
 
-        interfaces_command = 'show interfaces'
-
-        interfaces_ssh_reply = self._send_command(interfaces_command)
-
-        t = napalm_base.helpers.textfsm_extractor(self, "cisco_xr_show_interfaces", interfaces_ssh_reply)
-        t = napalm_base.helpers.textfsm_extractor(self, "cisco_xr_show_interfaces_admin", interfaces_ssh_reply)
-
-        return interfaces
+        uptime = self._send_command('show operational SystemTime uptime')
+        version = self._send_command('show version')
+        sn_model = self._send_command('show inventory rack')
+        fqdn = self._send_command('show configuration running-config domain name')
+        ifaces = self._send_command('show interfaces')
+        parsed_ifaces = napalm_base.helpers.textfsm_extractor(self, 'show_interfaces', ifaces)
+        for iface in parsed_ifaces:
+            facts['interface_list'].append(iface['interface'])
+        facts['uptime'] = int(uptime.split()[-1])
+        for line in uptime.splitlines():
+            if line.lower().startswith('hostname:'):
+                hostname = line.split()[-1]
+                break
+        for line in version.splitlines():
+            if line.lower().startswith('cisco ios xr software'):
+                facts['os_version'] = line.split('Version ')[-1]
+                break
+        if 'invalid input' in sn_model.lower():
+            facts['serial_number'] = None
+            facts['model'] = u'xrv'
+        else:
+            facts['serial_number'] = sn_model.splitlines()[-1].split()[-1]
+            facts['model'] = sn_model.splitlines()[-1].split()[-2]
+        facts['hostname'] = hostname
+        if 'no such configuration' in fqdn.lower():
+            facts['fqdn'] = hostname
+        else:
+            facts['fqdn'] = hostname + '.' + fqdn.split()[-1]
+        return facts

--- a/napalm_iosxr_ssh/utils/textfsm_templates/show_interfaces.tpl
+++ b/napalm_iosxr_ssh/utils/textfsm_templates/show_interfaces.tpl
@@ -1,0 +1,23 @@
+Value Required INTERFACE (\S+)
+Value LINK_STATUS (\w+)
+Value ADMIN_STATE (\S+)
+Value HARDWARE_TYPE (\w+)
+Value ADDRESS ([a-zA-Z0-9]+.[a-zA-Z0-9]+.[a-zA-Z0-9]+)
+Value BIA ([a-zA-Z0-9]+.[a-zA-Z0-9]+.[a-zA-Z0-9]+)
+Value DESCRIPTION (.*)
+Value IP_ADDRESS (\d+\.\d+\.\d+\.\d+\/\d+)
+Value MTU (\d+)
+Value DUPLEX (.+?)
+Value SPEED (.+?)
+Value BANDWIDTH (\d+\s+\w+)
+Value ENCAPSULATION (\w+)
+
+Start
+  ^${INTERFACE}\sis\s+${LINK_STATUS},\s+line\sprotocol\sis\s+${ADMIN_STATE}
+  ^\s+Hardware\s+is\s+${HARDWARE_TYPE}(\s+)?(Ethernet)?(,)?(\s+address\s+is\s+${ADDRESS}\s+\(bia\s+${BIA})?
+  ^\s+Description:\s+${DESCRIPTION}
+  ^\s+Internet\s+Address\s+is\s+${IP_ADDRESS}
+  ^\s+MTU\s+${MTU}.*BW\s+${BANDWIDTH}
+  ^\s+${DUPLEX}, ${SPEED},.+link 
+  ^\s+Encapsulation\s+${ENCAPSULATION}
+  ^\s+Last -> Record

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 napalm-base>=0.18.0
 pyIOSXR>=0.51
 netaddr
+sisqo>=2.1.1


### PR DESCRIPTION
This is a rewrite of the current iosxr_ssh driver implemented using the sisqo library for ssh connections, which issues commands and receives responses much quicker than the current implementation. Currently only get_facts is implemented but I'll be writing more methods soon.  