### PR TITLE
is_alive: fix #145

### DIFF
--- a/napalm_iosxr/iosxr.py
+++ b/napalm_iosxr/iosxr.py
@@ -18,7 +18,6 @@ from __future__ import unicode_literals
 # import stdlib
 import re
 import copy
-import socket
 from collections import defaultdict
 
 # import third party lib

--- a/napalm_iosxr/iosxr.py
+++ b/napalm_iosxr/iosxr.py
@@ -106,21 +106,18 @@ class IOSXRDriver(NetworkDriver):
         self.device.close()
 
     def is_alive(self):
+        """Returns a flag with the state of the connection."""
         null = chr(0)
+        if self.device is None:
+            return {'is_alive': False}
         try:
-            # Try sending ASCII null byte to maintain
-            #   the connection alive
-            self.device.device.send_command(null)
+            # Try sending ASCII null byte to maintain the connection alive
+            self.device.device.write_channel(null)
+            return {'is_alive': self.device.device.remote_conn.transport.is_active()}
         except (socket.error, EOFError):
-            # If unable to send, we can tell for sure
-            #   that the connection is unusable,
-            #   hence return False.
-            return {
-                'is_alive': False
-            }
-        return {
-            'is_alive': self.device.device.remote_conn.transport.is_active()
-        }
+            # If unable to send, we can tell for sure that the connection is unusable
+            return {'is_alive': False}
+        return {'is_alive': False}
 
     def load_replace_candidate(self, filename=None, config=None):
         self.pending_changes = True

--- a/napalm_iosxr/iosxr.py
+++ b/napalm_iosxr/iosxr.py
@@ -107,17 +107,10 @@ class IOSXRDriver(NetworkDriver):
 
     def is_alive(self):
         """Returns a flag with the state of the connection."""
-        null = chr(0)
-        if self.device is None:
-            return {'is_alive': False}
-        try:
-            # Try sending ASCII null byte to maintain the connection alive
-            self.device.device.write_channel(null)
-            return {'is_alive': self.device.device.remote_conn.transport.is_active()}
-        except (socket.error, EOFError):
-            # If unable to send, we can tell for sure that the connection is unusable
-            return {'is_alive': False}
-        return {'is_alive': False}
+        # Simply returns the flag from Netmiko
+        return {
+            'is_alive': self.device.device.is_alive()
+        }
 
     def load_replace_candidate(self, filename=None, config=None):
         self.pending_changes = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 napalm-base>=0.18.0
 pyIOSXR>=0.51
-netaddr
+netmiko>=1.4.3


### PR DESCRIPTION
Call write_channel instead of send_command so we are not trying to
read the command line, but just send the null byte.
This also adds some better checks, i.e., the connection is not
initialized, unable to send the null byte, etc.

Finally closes #145. We will probably move this checks into Netmiko soon, to avoid redundancy.