### PR TITLE
Remove download counter which no longer works

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![PyPI](https://img.shields.io/pypi/v/napalm-iosxr.svg)](https://pypi.python.org/pypi/napalm-iosxr)
-[![PyPI](https://img.shields.io/pypi/dm/napalm-iosxr.svg)](https://pypi.python.org/pypi/napalm-iosxr)
 [![Build Status](https://travis-ci.org/napalm-automation/napalm-iosxr.svg?branch=master)](https://travis-ci.org/napalm-automation/napalm-iosxr)
 [![Coverage Status](https://coveralls.io/repos/github/napalm-automation/napalm-iosxr/badge.svg?branch=master)](https://coveralls.io/github/napalm-automation/napalm-iosxr)
 


### PR DESCRIPTION
Removing the download counter which has stopped working:
[![PyPI](https://img.shields.io/pypi/dm/napalm-iosxr.svg)](https://pypi.python.org/pypi/napalm-iosxr)

It can give the wrong impression of the project. And of course, so that everything looks nice for the hacktoberfest. :)